### PR TITLE
Reduce the risk of filename being cut off in small windows

### DIFF
--- a/neovim/.config/nvim/lua/railslide/plugins/lualine.lua
+++ b/neovim/.config/nvim/lua/railslide/plugins/lualine.lua
@@ -11,13 +11,20 @@ return {
     vim.opt.showmode = false
 
     lualine.setup({
+      options = {
+        component_separators = '',
+        section_separators = '',
+      },
       sections = {
+        lualine_b = {'filename'},
+        lualine_c = {},
         lualine_x = {
           {
             lazy_status.updates, -- Show if there are available updates for plugins
             cond = lazy_status.has_updates,
             color = { fg = "#ff9e64" },
           },
+          {'diagnostics'},
           {'encoding'},
           {'fileformat'},
           {'filetype'},


### PR DESCRIPTION
- Remove git info
- Remove separators
- Move diagnostics to the rights