### PR TITLE
Do not lazy load Carbon

### DIFF
--- a/neovim/.config/nvim/lazy-lock.json
+++ b/neovim/.config/nvim/lazy-lock.json
@@ -11,8 +11,8 @@
   "mason.nvim": { "branch": "main", "commit": "e110bc3be1a7309617cecd77bfe4bf86ba1b8134" },
   "nvim-autopairs": { "branch": "master", "commit": "9fd41181693dd4106b3e414a822bb6569924de81" },
   "nvim-cmp": { "branch": "main", "commit": "538e37ba87284942c1d76ed38dd497e54e65b891" },
-  "nvim-lspconfig": { "branch": "master", "commit": "796394fd19fb878e8dbc4fd1e9c9c186ed07a5f4" },
-  "nvim-web-devicons": { "branch": "master", "commit": "db0c864375c198cacc171ff373e76bfce2a85045" },
+  "nvim-lspconfig": { "branch": "master", "commit": "7eed8b2150192e5ad05e1886fdf133493ddf2928" },
+  "nvim-web-devicons": { "branch": "master", "commit": "4f5e6414438c920743fc1bb92bee1047620d6321" },
   "onedark.nvim": { "branch": "master", "commit": "dc3bad0121298f89b50aaff8599d1946e07eb4c2" },
   "plenary.nvim": { "branch": "master", "commit": "55d9fe89e33efd26f532ef20223e5f9430c8b0c0" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "d90956833d7c27e73c621a61f20b29fdb7122709" }

--- a/neovim/.config/nvim/lua/railslide/plugins/carbon.lua
+++ b/neovim/.config/nvim/lua/railslide/plugins/carbon.lua
@@ -1,6 +1,5 @@
 return {
   'SidOfc/carbon.nvim',
-  event = "VeryLazy",
 
   config = function ()
     require('carbon').setup({


### PR DESCRIPTION
If lazy-loaded, Carbon will not be ready when running `nvim .` and
netrw will be launched instead
