### PR TITLE
Update property name in foot config

### DIFF
--- a/foot/.config/foot/foot.ini
+++ b/foot/.config/foot/foot.ini
@@ -74,7 +74,7 @@ font=SauceCodePro NFM:size=12
 [touch]
 # long-press-delay=400
 
-[colors]
+[colors-dark]
 # alpha=1.0
 background=2d3743
 foreground=d8dee9


### PR DESCRIPTION
[colors] is deprecated and replaces by [colors-dark]